### PR TITLE
Return Http status code when API get() returns None. Added forbidden view for API request.

### DIFF
--- a/pyconca/api/base_api.py
+++ b/pyconca/api/base_api.py
@@ -41,8 +41,6 @@ class BaseApi(object):
 
     def index(self):
         models = self.dao.index()
-        if models is None:
-            return self._respond(HTTP_STATUS_404)  # TODO not sure if right
         self.body['data'][self.name + '_list'] = [m.to_dict() for m in models]
         return self._respond(HTTP_STATUS_200)
 

--- a/pyconca/api/base_api.py
+++ b/pyconca/api/base_api.py
@@ -4,6 +4,7 @@ import logging
 from formencode import Invalid
 
 from pyramid.response import Response
+from pyramid.view import forbidden_view_config
 
 
 log = logging.getLogger(__name__)
@@ -19,13 +20,17 @@ class FormencodeState(object):
     pass
 
 
+def is_api_request(info, request):
+    return request['PATH_INFO'].endswith('.json') is True
+
+
 class BaseApi(object):
 
     def __init__(self, request):
         self.request = request
         self._configure()
         self.state = FormencodeState()
-        self.body = {'errors':[], 'data':{}}
+        self.body = {'errors': [], 'data': {}}
 
     @property
     def id(self):
@@ -36,11 +41,15 @@ class BaseApi(object):
 
     def index(self):
         models = self.dao.index()
+        if models is None:
+            return self._respond(HTTP_STATUS_404)  # TODO not sure if right
         self.body['data'][self.name + '_list'] = [m.to_dict() for m in models]
         return self._respond(HTTP_STATUS_200)
 
     def get(self):
         model = self.dao.get(self.id)
+        if model is None:
+            return self._respond(HTTP_STATUS_404)
         self.body['data'][self.name] = model.to_dict()
         return self._respond(HTTP_STATUS_200)
 
@@ -102,7 +111,7 @@ class BaseApi(object):
 
     def _add_validation_errors(self, invalid_exception):
         for field, message in invalid_exception.error_dict.items():
-            error = {'field':field, 'message':message.msg}
+            error = {'field': field, 'message': message.msg}
             self.body['errors'].append(error)
 
     def _respond(self, status):
@@ -110,3 +119,9 @@ class BaseApi(object):
             status=status,
             body=json.dumps(self.body),
             content_type='application/json')
+
+    #--------- permission unmet
+    @forbidden_view_config(renderer='json',
+                           custom_predicates=(is_api_request,))
+    def _forbidden(self):
+        return self._respond(HTTP_STATUS_403)

--- a/pyconca/security.py
+++ b/pyconca/security.py
@@ -4,6 +4,7 @@ from pyramid.security import authenticated_userid
 from pyramid.security import unauthenticated_userid
 from pyramid.security import Allow
 from pyramid.security import Everyone
+from pyramid.security import Authenticated
 
 from pyconca.dao.user_dao import UserDao
 from pyconca.dao.talk_dao import TalkDao
@@ -79,13 +80,13 @@ class UserFactory(object):
 
 class TalkFactory(object):
     __acl__ = [
-        (Allow, Everyone, 'talk_create'),
+        (Allow, Authenticated, 'talk_create'),
         (Allow, 'group:admin', 'talk_index'),
         (Allow, 'group:admin', 'talk_get'),
         (Allow, 'group:admin', 'talk_update'),
         (Allow, 'group:admin', 'talk_delete'),
 
-        (Allow, Everyone, 'api_talk_create'),
+        (Allow, Authenticated, 'api_talk_create'),
         (Allow, 'group:admin', 'api_talk_index'),
         (Allow, 'group:admin', 'api_talk_get'),
         (Allow, 'group:admin', 'api_talk_update'),
@@ -97,6 +98,7 @@ class TalkFactory(object):
         user = request.user
         talk_dao = TalkDao()
         if (user_id and user and 'id' in request.matchdict and
+            talk_dao.get(int(request.matchdict['id'])) and
             user.id == talk_dao.get(int(request.matchdict['id'])).owner_id):
                 self.__acl__.append((Allow, user_id, 'talk_get'))
                 self.__acl__.append((Allow, user_id, 'api_talk_get'))

--- a/pyconca/templates/talk/talk_edit.mako
+++ b/pyconca/templates/talk/talk_edit.mako
@@ -92,6 +92,7 @@
         </div>
     </div>
 
+  % if is_admin:
     <div class="control-group">
         <label class="control-label" for="reviewer_notes">Reviewer Notes</label>
         <div class="controls">
@@ -99,6 +100,7 @@
             </textarea>
         </div>
     </div>
+  % endif
 </script>
 
 <script type="text/javascript">
@@ -152,9 +154,6 @@
         % else:
             var url = "${request.route_url('api_talk_update', id=id)}";
         % endif
-
-        console.log(url);
-        console.log(request);
 
         $.post(url, request)
             .success(function() {

--- a/pyconca/templates/talk/talk_get.mako
+++ b/pyconca/templates/talk/talk_get.mako
@@ -49,9 +49,11 @@
     <strong>Outline</strong>
     <span>{{talk.outline}}</span>
 
+  % if is_admin:
     <br>
     <strong>Reviewer Notes:</strong>
     <span>{{talk.reviewer_notes}}</span>
+  % endif
 </script>
 
 <script type="text/javascript">

--- a/pyconca/templates/talk/talk_index.mako
+++ b/pyconca/templates/talk/talk_index.mako
@@ -23,7 +23,9 @@
             <th>Level</th>
             <th>Abstract</th>
             <th>Outline</th>
+          % if is_admin:
             <th>Reviewer Notes</th>
+          % endif
         </tr>
         {{#talk_list}}
         <tr>
@@ -36,7 +38,9 @@
           <td>{{level}}</td>
           <td>{{abstract}}</td>
           <td>{{outline}}</td>
+        % if is_admin:
           <td>{{reviewer_notes}}</td>
+        % endif
         </tr>
         {{/talk_list}}
     </table>


### PR DESCRIPTION
If `dao.get(id)` returns `None`, then API respond with `HTTP_STATUS_404`.

Added a `_forbidden` view for API calls that does not have valid permission.
