### PR TITLE
Talk schedule backend

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -22,6 +22,8 @@ mako.strict_undefined = true
 mako.imports = from markupsafe import escape_silent
 mako.default_filters = escape_silent
 
+timezone = America/Toronto
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/production_example.ini
+++ b/production_example.ini
@@ -21,6 +21,8 @@ mako.strict_undefined = true
 mako.imports = from markupsafe import escape_silent
 mako.default_filters = escape_silent
 
+timezone = America/Toronto
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/pyconca/__init__.py
+++ b/pyconca/__init__.py
@@ -2,6 +2,7 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.session import UnencryptedCookieSessionFactoryConfig
+import pytz
 
 from sqlalchemy import engine_from_config
 
@@ -12,10 +13,16 @@ from .routes import _setup_routes
 from .security import get_user
 from .security import permission_finder
 
+default_timezone = pytz.timezone('America/Toronto')
 
 def main(global_config, **settings):
+    global default_timezone
+
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
+
+    if 'timezone' in settings:
+        default_timezone = pytz.timezone(settings['timezone'])
 
     authn_policy = AuthTktAuthenticationPolicy(
         settings['secret.authn_policy'],

--- a/pyconca/api/talk_api.py
+++ b/pyconca/api/talk_api.py
@@ -77,16 +77,23 @@ class TalkApi(BaseApi):
             'conf_key': output['id'],
             'conf_url': route_url('talk_get', request, id=output['id']),
         })
+        schedule = {
+            'room': None,
+            'start': None,
+            'end': None,
+            'duration': None,
+        }
         if model.schedule_slot:
             assert model.schedule_slot.start < model.schedule_slot.end
             duration_delta = model.schedule_slot.end - model.schedule_slot.start
             assert duration_delta.days == 0
-            new_output.update({
+            schedule.update({
                 'room': model.schedule_slot.room,
                 'start': self._local_isoformat(model.schedule_slot.start),
                 'end': self._local_isoformat(model.schedule_slot.end),
                 'duration': (model.schedule_slot.end - model.schedule_slot.start).seconds / 60,
             })
+        new_output.update(schedule)
         return new_output
 
 

--- a/pyconca/models.py
+++ b/pyconca/models.py
@@ -1,5 +1,7 @@
 from sqlalchemy import Column
+from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
+from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
@@ -92,6 +94,7 @@ class Talk(AttrMixIn, Base):
     abstract = Column(String(length=400), nullable=False)
     outline = Column(Text(), nullable=False)
     reviewer_notes = Column(Text(), default='')
+    schedule_slot = relationship('ScheduleSlot', secondary='talk_schedule_slot', single_parent=True, uselist=False)
 
     @property
     def __acl__(self):
@@ -121,3 +124,16 @@ class Talk(AttrMixIn, Base):
             data['reviewer_notes'] = self.reviewer_notes
 
         return data
+
+class ScheduleSlot(AttrMixIn, Base):
+    id = Column(Integer, primary_key=True)
+    room = Column(String(length=100), nullable=False)
+    start = Column(DateTime, nullable=False)
+    end = Column(DateTime, nullable=False)
+
+class TalkScheduleSlot(AttrMixIn, Base):
+    talk_id = Column(Integer, ForeignKey('talk.id'), primary_key=True)
+    schedule_slot_id = Column(Integer, ForeignKey('schedule_slot.id'), primary_key=True)
+
+Index("talk_schedule_slot_talk_id_unique", TalkScheduleSlot.talk_id, unique=True)
+Index("talk_schedule_slot_schedule_slot_id_unique", TalkScheduleSlot.schedule_slot_id, unique=True)

--- a/pyconca/tests/test_with_webtest.py
+++ b/pyconca/tests/test_with_webtest.py
@@ -108,6 +108,12 @@ class TestWithWebtest(unittest.TestCase):
 
     ### TALK API
 
+    def _assertTalkNotScheduled(self, data):
+        self.assertTrue(data['data']['talk']['room'] is None)
+        self.assertTrue(data['data']['talk']['start'] is None)
+        self.assertTrue(data['data']['talk']['end'] is None)
+        self.assertTrue(data['data']['talk']['duration'] is None)
+
     def test_talk_api_index__not_logged_in(self):
         data = self._getJsonFrom('/talk.json', status=403)
         self.assertEquals({}, data['data'])
@@ -130,10 +136,12 @@ class TestWithWebtest(unittest.TestCase):
     def test_talk_api_get_admin__as_admin(self):
         data = self._getJsonFrom('/talk/11.json', who='admin', status=200)
         self.assertEquals(self._admin_talk_id, data['data']['talk']['id'])
+        self._assertTalkNotScheduled(data)
 
     def test_talk_api_get_speaker__as_admin(self):
         data = self._getJsonFrom('/talk/12.json', who='admin', status=200)
         self.assertEquals(self._speaker_talk_id, data['data']['talk']['id'])
+        self._assertTalkNotScheduled(data)
 
     def test_talk_api_get_admin__as_speaker(self):
         data = self._getJsonFrom('/talk/11.json', who='speaker', status=403)
@@ -142,6 +150,7 @@ class TestWithWebtest(unittest.TestCase):
     def test_talk_api_get_speaker__as_speaker(self):
         data = self._getJsonFrom('/talk/12.json', who='speaker', status=200)
         self.assertEquals(self._speaker_talk_id, data['data']['talk']['id'])
+        self._assertTalkNotScheduled(data)
 
     def test_talk_api_unscheduled(self):
         start = datetime(2012, 11, 10, 15, 00)

--- a/pyconca/tests/test_with_webtest.py
+++ b/pyconca/tests/test_with_webtest.py
@@ -153,6 +153,6 @@ class TestWithWebtest(unittest.TestCase):
             DBSession.add(talk_slot)
         data = self._getJsonFrom('/talk/11.json', who='admin', status=200)
         self.assertEquals("room", data['data']['talk']['room'])
-        self.assertEquals(start.isoformat() + "+00:00", data['data']['talk']['start'])
-        self.assertEquals(end.isoformat() + "+00:00", data['data']['talk']['end'])
+        self.assertEquals("2012-11-10T10:00:00-05:00", data['data']['talk']['start'])
+        self.assertEquals("2012-11-10T10:30:00-05:00", data['data']['talk']['end'])
         self.assertEquals(30, data['data']['talk']['duration'])

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requires = [
     'py-bcrypt',
     'pyramid_tm',
     'pyramid_debugtoolbar',
+    'pytz',
     'zope.sqlalchemy',
     'waitress',
     ]


### PR DESCRIPTION
Creates tables to store schedule slots, and an association table with restriction to ensure that talks and slots can't be double-booked.

If a talk has an associated slot, that data will show up in the JSON data for the talk.

I also added a default timezone so we can just display things "here" but store them in UTC.

I haven't hooked up any UI for the slots or associations yet, nor hooked it into the HTML version of the talk data.

Totally happy to talk about whether this is a good data model or not. Better to get that ironed out first before committing data to it!
