### PR TITLE
BNOTIONS logo

### DIFF
--- a/pyconca/templates/sponsors/bnotions.mako
+++ b/pyconca/templates/sponsors/bnotions.mako
@@ -2,6 +2,6 @@
 <a href="http://bnotions.com" style="border-bottom: none;">
     <img src="${request.static_url("pyconca:static/BNOTIONS.png")}"
         class="${img_class}"
-        width="200" height="100"
+        width="200"
         alt="BNOTIONS">
 </a>


### PR DESCRIPTION
The BNOTIONS logo is vertically stretched. Removed "height" to fix this issue.
