### PR TITLE
Simplify predicates for default forbidden view

### DIFF
--- a/pyconca/api/base_api.py
+++ b/pyconca/api/base_api.py
@@ -22,7 +22,7 @@ class FormencodeState(object):
 
 
 def is_api_request(info, request):
-    return request.environ['PATH_INFO'].endswith('.json') is True
+    return request.path.endswith('.json')
 
 
 class BaseApi(Context):

--- a/pyconca/views.py
+++ b/pyconca/views.py
@@ -11,9 +11,6 @@ from pyconca.security import is_admin
 from pyconca.locale import locale_cookie_headers
 from pyramid.i18n import get_locale_name
 
-def is_not_api_request(info, request):
-    return request.environ['PATH_INFO'].endswith('.json') == False
-
 
 @view_config(route_name='index', renderer='index.mako')
 def index(request):
@@ -76,8 +73,7 @@ def logout(request):
 
 @view_config(route_name='login', renderer='pyconca:templates/auth/login.mako')
 @forbidden_view_config(
-        renderer='pyconca:templates/auth/login.mako',
-        custom_predicates=(is_not_api_request,))
+        renderer='pyconca:templates/auth/login.mako')
 def login(request):
     login_url = request.route_url('login')
     referrer = request.url


### PR DESCRIPTION
custom_predicates are not neccessary provide a fallback
against another view_config with custom_predicates.

Also use pyramid built in path properties on request.
