### PR TITLE
Rudimentary SEO targeting for “Python Canada” keyword phrase.

### DIFF
--- a/pyconca/templates/about.mako
+++ b/pyconca/templates/about.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"About")}
 </%block>
 

--- a/pyconca/templates/base.mako
+++ b/pyconca/templates/base.mako
@@ -2,9 +2,11 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta charset="utf-8" />
-    <title>PyCon Canada</title>
+    <title><%block name="head_title"></%block> | PyCon Canada</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="" />
+    <meta name="description"
+    	content='<%block name="head_description">Your connection to the Python Canada community. We are the momentum 
+    	behind the Canadian PyCon conference, and the source for local Python programmers, events, and jobs.</%block>' />
     <meta name="author" content="" />
 
     <link href="${request.static_url("pyconca:static/libs/bootstrap-2.0.3/css/bootstrap.css")}" rel="stylesheet" />

--- a/pyconca/templates/conduct.mako
+++ b/pyconca/templates/conduct.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title" filter="gettext">Code of Conduct</%block>
+<%block name="head_title" filter="gettext">Code of Conduct</%block>
 
 <%block name="info">
     <div class="row-fluid content-section">

--- a/pyconca/templates/contact.mako
+++ b/pyconca/templates/contact.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Contact")}
 </%block>
 

--- a/pyconca/templates/event.mako
+++ b/pyconca/templates/event.mako
@@ -9,6 +9,7 @@
         <h1 class="header-main-text"><%block name="title"/></h1>
         <h2 class="header-sub-text">${_(u"PyCon Canada 2012")}</h2>
         <h2 class="header-sub-text">${_(u"Toronto, November 9th - 11th")}</h2>
+        <h3 class="header-sub-text">${_(u"Bringing the Python Canada community together")}</h3>
       </div>
     </div>
   </div>

--- a/pyconca/templates/generic.mako
+++ b/pyconca/templates/generic.mako
@@ -9,6 +9,7 @@
         <br>
         <h1 class="header-main-text">${_(u"PyCon Canada")}</h1>
         <h2 class="header-sub-text">${_(u"Toronto, November 9th - 11th 2012")}</h2>
+        <h3 class="header-sub-text">${_(u"Bringing the Python Canada community together")}</h3>
       </div>
     </div>
   </div>

--- a/pyconca/templates/index.mako
+++ b/pyconca/templates/index.mako
@@ -1,4 +1,7 @@
 <%inherit file="base.mako"/>
+<%block name="head_title">PyCon.ca - building your Python Canada Community</%block>
+<%block name="head_description">${parent.head_description()}</%block>
+
 <%block name="content">
 
 <div class="row-fluid main-header-image">
@@ -12,6 +15,7 @@
       <div class="span12 top-row main-row overlay">
         <h1 class="header-main-text">${_(u"PyCon Canada")}</h1>
         <h2 class="header-sub-text">${_(u"Toronto, November 9th - 11th 2012")}</h2>
+        <h3 class="header-sub-text">${_(u"Bringing the Canadian Python community together")}</h3>
         <br />
         <div class="visible-desktop">
             <a href="http://guestlistapp.com/events/116013" class="btn btn-warning btn-large guestlist-event-116013">${_(u"Register")}</a>

--- a/pyconca/templates/learn.mako
+++ b/pyconca/templates/learn.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_("Confirmed Speakers")}
 </%block>
 

--- a/pyconca/templates/schedule.mako
+++ b/pyconca/templates/schedule.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Schedule")}
 </%block>
 

--- a/pyconca/templates/speakers.mako
+++ b/pyconca/templates/speakers.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Speakers")}
 </%block>
 

--- a/pyconca/templates/sponsors.mako
+++ b/pyconca/templates/sponsors.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Sponsor")}
 </%block>
 

--- a/pyconca/templates/sponsors_500px.mako
+++ b/pyconca/templates/sponsors_500px.mako
@@ -1,6 +1,6 @@
 <%inherit file="pyconca:templates/sponsor_profile.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     Gold Sponsor - <a href="http://500px.com/">500px</a>
 </%block>
 

--- a/pyconca/templates/sprints.mako
+++ b/pyconca/templates/sprints.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Sprints")}
 </%block>
 

--- a/pyconca/templates/venue.mako
+++ b/pyconca/templates/venue.mako
@@ -1,6 +1,6 @@
 <%inherit file="event.mako"/>
 
-<%block name="title">
+<%block name="head_title">
     ${_(u"Venue")}
 </%block>
 


### PR DESCRIPTION
Added template blocks `head_title` and `head_description` to
`base.make`. Optimized these HTML tags and added an additional header to
target “Python Canada” phrase in `index.mako`. As of right now the site
does not rank within the first 50 results for Python Canada. 

It also appears block `title` was to exist in `base.mako` as secondary
pages were referencing it; updated all pages to utilize the new
`head_title` block.
