### PR TITLE
Missing title on Schedule page

### DIFF
--- a/pyconca/templates/schedule.mako
+++ b/pyconca/templates/schedule.mako
@@ -3,6 +3,7 @@
 <%block name="head_title">
     ${_(u"Schedule")}
 </%block>
+<%block name="title">${_(u"Schedule")}</%block>
 
 <%def name="slot(code)">
   <%


### PR DESCRIPTION
Just noticed this, not sure if it got lost in a merge somewhere.
