### PR TITLE
Makes pyconca_update_talk_slots store datetimes in UTC.

### DIFF
--- a/pyconca/scripts/update_talk_slots.py
+++ b/pyconca/scripts/update_talk_slots.py
@@ -5,7 +5,9 @@ import sys
 from collections import namedtuple
 from datetime import datetime, timedelta
 
+import pytz
 import transaction
+from pyconca.temporal import default_timezone
 from pyramid.paster import get_appsettings
 from pyramid.paster import setup_logging
 from sqlalchemy import engine_from_config
@@ -88,7 +90,10 @@ def _parse_schedule(schedule):
             hour, minute = map(int, time_m.groups())
 
             s = Slot(
-                start=start_date + timedelta(days=day, hours=hour, minutes=minute),
+                start=default_timezone.localize(
+                    start_date +
+                    timedelta(days=day, hours=hour, minutes=minute)
+                ).astimezone(pytz.utc),
                 end=None,
                 code=None,
                 room=None,

--- a/pyconca/templates/talk/talk_get.mako
+++ b/pyconca/templates/talk/talk_get.mako
@@ -49,6 +49,12 @@
         <br>
         <strong>Level:</strong>
         <span>{{talk.level}}</span>
+        <br>
+        <strong>When:</strong>
+        <span>{{pycon_time talk.start talk.duration}}</span>
+        <br>
+        <strong>Where:</strong>
+        <span>{{talk.room}}</span>
     </fieldset>
 
     <br>

--- a/pyconca/templates/talk/talk_index.mako
+++ b/pyconca/templates/talk/talk_index.mako
@@ -26,6 +26,8 @@
             <th>Speaker</th>
             <th>Type</th>
             <th>Level</th>
+            <th>When</th>
+            <th>Where</th>
         </tr>
         {{#talk_list}}
         <tr>
@@ -37,6 +39,8 @@
           <td>{{speaker_first_name}} {{speaker_last_name}}</td>
           <td>{{type}}</td>
           <td>{{level}}</td>
+          <td>{{pycon_time start duration}}</td>
+          <td>{{room}}</td>
         </tr>
         {{/talk_list}}
     </table>


### PR DESCRIPTION
Should let us back out the previous commit, which removed the not-right-looking times from display.
