### PR TITLE
Disqus commenting for talks

### DIFF
--- a/pyconca/templates/schedule.mako
+++ b/pyconca/templates/schedule.mako
@@ -11,9 +11,11 @@
     slot = slots.get(code)
     talk = slot and slot.talk
     owner = talk and talk.owner
+    talk_url = talk and request.route_url('talk_get', id=talk.id)
   %>
 
   ${render_slot(
+    talk_url,
     (talk and talk.title),
     (owner and "%s %s" %(owner.first_name, owner.last_name)),
     (slot and slot.room),
@@ -21,7 +23,7 @@
   )}
 </%def>
 
-<%def name="render_slot(title, owner_name, room, code)">
+<%def name="render_slot(talk_url, title, owner_name, room, code)">
   <div class="talk-slot">
     % if title is None:
       <strong>TBA</strong> (${code})
@@ -35,8 +37,14 @@
         title_style = "font-style: italic;"
     %>
 
-    <strong style="${title_style}">${title}</strong> by
-    <strong>${owner_name}</strong>
+    % if talk_url:
+        <a href="${talk_url}">
+    % endif
+        <strong style="${title_style}">${title}</strong> by
+        <strong>${owner_name}</strong>
+    % if talk_url:
+        </a>
+    % endif
     <span class="talk-meta-phone">
       ${room.title()} • ${code}
       % if "T" in code:
@@ -108,7 +116,7 @@
           <tr>
             <th>9:30</th>
             <td colspan="3">
-              ${render_slot(_("Morning Keynote"), "Jessica McKellar", "Main Hall", "K1")}
+              ${render_slot('', _("Morning Keynote"), "Jessica McKellar", "Main Hall", "K1")}
             </td>
           </tr>
 
@@ -346,7 +354,7 @@
           <tr>
             <th>9:15</th>
             <td colspan="3">
-              ${render_slot(_("Morning Keynote"), "Michael Feathers", "Main Hall", "K2")}
+              ${render_slot('', _("Morning Keynote"), "Michael Feathers", "Main Hall", "K2")}
             </td>
           </tr>
 
@@ -515,7 +523,7 @@
           <tr>
             <th>4:40</th>
             <td colspan="3">
-              ${render_slot(_("Closing Keynote"), u"Fernando Pérez", "Main Hall", "K3")}
+              ${render_slot('', _("Closing Keynote"), u"Fernando Pérez", "Main Hall", "K3")}
             </td>
           </tr>
 

--- a/pyconca/templates/talk/talk_get.mako
+++ b/pyconca/templates/talk/talk_get.mako
@@ -125,5 +125,20 @@
     });
 </script>
 
+<div id="disqus_thread"></div>
+<script type="text/javascript">
+    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+    var disqus_shortname = 'pyconca'; // required: replace example with your forum shortname
+
+    /* * * DON'T EDIT BELOW THIS LINE * * */
+    (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+
 </%block>
 


### PR DESCRIPTION
Makes links from the schedule page to the individual talk pages (these were already public, but impossible to find). Each talk page also gets its own Disqus thread as a backchannel for discussion.

I've got the creds for the Disqus account, and can add people as moderators on request.
